### PR TITLE
feat: Remove Ruby dependency to `rutie`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require "rbconfig"
 require "bundler/gem_tasks"
 require "rake/testtask"
 

--- a/crates/rutie-test/src/lib.rs
+++ b/crates/rutie-test/src/lib.rs
@@ -9,14 +9,7 @@ root = File.expand_path("../..", ENV["CARGO_MANIFEST_DIR"])
 
 Dir.chdir(root)
 
-class RbConfig
-  CONFIG = {{
-    "host_os" => ENV["TARGET"]
-  }}
-end
-
 $LOAD_PATH.unshift(File.expand_path("lib", root))
-$LOAD_PATH.unshift(File.expand_path("vendor/bundle/rutie/lib", root))
 
 require "wasmer"
 

--- a/crates/wasmer/build.rs
+++ b/crates/wasmer/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-    // To satisfy `rutie-test`'s macros.
-    println!(
-        "cargo:rustc-env=TARGET={}",
-        std::env::var("TARGET").unwrap()
-    );
-}

--- a/lib/wasmer.rb
+++ b/lib/wasmer.rb
@@ -1,5 +1,32 @@
-require "rutie"
+require "fiddle"
 
 module Wasmer
-  Rutie.new(:wasmer_ruby).init "init", __dir__
+  shared_library_name = :wasmer_ruby
+  init_function = :init
+
+  shared_library_prefix =
+    case RUBY_PLATFORM
+    when /windows|mswin|mingw/ then ""
+    when /cygwin/ then "cyg"
+    else "lib"
+    end
+
+  shared_library_suffix =
+    case RUBY_PLATFORM
+    when /darwin/ then "dylib"
+    when /windows|mswin|mingw|cygwin/ then "dll"
+    else "so"
+    end
+
+  shared_library_directory = File.expand_path "../target/release/", __dir__
+  shared_library_path = File.join(
+    shared_library_directory,
+    [shared_library_prefix, shared_library_name, ".", shared_library_suffix].join()
+  )
+
+  Fiddle::Function.new(
+    Fiddle::dlopen(shared_library_path)[init_function.to_s],
+    [],
+    Fiddle::TYPE_VOIDP
+  ).call
 end

--- a/wasmer.gemspec
+++ b/wasmer.gemspec
@@ -15,12 +15,11 @@ Gem::Specification.new do |spec|
   spec.extensions    = %w(Rakefile)
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(examples|tests)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(examples|tests|doc)/}) }
   end
 
   spec.require_paths = %w(lib)
 
-  spec.add_dependency "rutie", "~> 0.0.4"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
By removing the dependency to `rutie` for the Ruby code (not for the
Rust code!), we can simplify our Rust code, including the Rust
doctests:

* No need to emulate `RbConfig`,
* So no need to have a build script for `wasmer` (`build.rs`),
* No need to get `rbconfig` in `Rakefile`,
* No need to manually add `rutie` to `$LOAD_PATh` when doctesting.