### PR TITLE
test: Test examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,4 +70,4 @@ jobs:
         shell: bash
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
-          just test
+          just test-all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0"
+version = "0.5.0"
 dependencies = [
  "lazy_static",
  "rutie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -722,9 +722,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1119,9 +1119,9 @@ checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
 
 [[package]]
 name = "wasmparser"
-version = "0.78.0"
+version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7a8b20306d43c09c2c34e0ef68bf2959a11b01a5cae35e4c5dc1e7145547b6"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmprinter"
@@ -1130,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ccec894c70710c2e4669320a532cb2b9cfb97adb0429745642f8ce76916ed85"
 dependencies = [
  "anyhow",
- "wasmparser 0.78.0",
+ "wasmparser 0.78.2",
 ]
 
 [[package]]

--- a/crates/wasmer/README.md
+++ b/crates/wasmer/README.md
@@ -170,11 +170,12 @@ too!
 
 ### Testing
 
-Running the `test` recipe will automatically build and run all the
-tests. It includes library tests, along with documentation tests.
+Running the `test-all` recipe will automatically build and run all the
+tests. It includes library tests, along with documentation tests and
+the examples:
 
 ```sh
-$ just test
+$ just test-all
 ```
 
 ### Documentation

--- a/crates/wasmer/README.md
+++ b/crates/wasmer/README.md
@@ -26,7 +26,7 @@
   <h3>
     <a href="https://wasmer.io/">Website</a>
     <span> • </span>
-    <a href="https://docs.wasmer.io">Docs</a>
+    <a href="https://wasmerio.github.io/wasmer-ruby/wasmer_ruby/index.html">Docs</a>
     <span> • </span>
     <a href="https://slack.wasmer.io/">Slack Channel</a>
   </h3>

--- a/examples/compiler_cranelift.rb
+++ b/examples/compiler_cranelift.rb
@@ -1,4 +1,4 @@
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # A Wasm module can be compiled with multiple compilers.
 #

--- a/examples/engine_jit.rb
+++ b/examples/engine_jit.rb
@@ -1,4 +1,4 @@
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # Defining an engine in Wasmer is one of the fundamental steps.
 #

--- a/examples/exports_function.rb
+++ b/examples/exports_function.rb
@@ -1,4 +1,4 @@
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # A Wasm module can export entities, like functions, memories,
 # globals and tables.

--- a/examples/exports_global.rb
+++ b/examples/exports_global.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # A Wasm module can export entities, like functions, memories, globals
 # and tables.

--- a/examples/exports_memory.rb
+++ b/examples/exports_memory.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # A Wasm module can export entities, like functions, memories,
 # globals and tables.

--- a/examples/imports_function.rb
+++ b/examples/imports_function.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # A Wasm module can import entities, like functions, memories,
 # globals and tables.

--- a/examples/imports_function_early_exit.rb
+++ b/examples/imports_function_early_exit.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # A Wasm module can import entities, like functions, memories,
 # globals and tables.

--- a/examples/instance.rb
+++ b/examples/instance.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # Wasmer will let you easily run WebAssembly module in a Ruby host.
 #

--- a/examples/wasi.rb
+++ b/examples/wasi.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require "./prelude"
+require File.expand_path "../prelude", __FILE__
 
 # Running a WASI compiled WebAssembly module with Wasmer.
 #

--- a/justfile
+++ b/justfile
@@ -4,9 +4,21 @@ build:
 	rake bundle_install
 
 # Run all the tests.
-test:
+test-all: test-lib test-doc test-example
+
+# Run the tests of the library.
+test-lib:
 	rake test
+
+# Run the tests of the documentation.
+test-doc:
 	cargo test --manifest-path crates/wasmer/Cargo.toml --doc
+
+# Run the examples as tests.
+test-example:
+	for example in $(ls examples/*.rb); do \
+		ruby $example; \
+	done
 
 # Build the `.gem` file.
 gem:


### PR DESCRIPTION
This PR updates the CI script to run the new `test-all` recipe. This recipe executes the new `test-lib`, `test-doc` and `test-example` recipes. `test-lib` and `test-doc` are from the previous `test` recipe. The `test-example` recipe is new and runs all the examples as tests.