### PR TITLE
Remove bundle install rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,7 @@ task :build_lib do
   sh 'cargo build --release --manifest-path crates/wasmer/Cargo.toml'
 end
 
-desc 'Install the bundle'
-task :bundle_install do
-  sh 'bundle config set --local path "vendor/bundle"'
-  sh 'bundle install'
-  sh 'cd vendor/bundle && ln -f -s ruby/*/gems/rutie-*/ rutie'
-end
-
-Rake::TestTask.new(test: [:bundle_install, :build_lib]) do |t|
+Rake::TestTask.new(test: :build_lib) do |t|
   t.libs << "tests"
   t.libs << "lib"
   t.test_files = FileList["tests/*_test.rb"]

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,4 @@ Rake::TestTask.new(test: :build_lib) do |t|
   t.test_files = FileList["tests/*_test.rb"]
 end
 
-task :default => :test
+task :default => :build_lib

--- a/wasmer.gemspec
+++ b/wasmer.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-reporters"  
 end


### PR DESCRIPTION
Wonderful library. We use it for our app [publishers](https://github.com/brave-intl/publishers). 

This PR resolves [this ticket](https://github.com/rubygems/rubygems/issues/4838). An install would break our build because of the call to bundle in `Rakefile`. I've added these as development dependencies and make the default task the one that builds the library. Ideally, we'd package a native gem like mentioned [here](https://tristanpenman.com/blog/posts/2018/08/29/writing-a-gem-with-native-extensions/), but this at least stops us from polluting the bundle namespace and breaking builds.