### PR TITLE
Properly convert bytes to UTF-8 in examples/exports_memory.rb

### DIFF
--- a/examples/exports_memory.rb
+++ b/examples/exports_memory.rb
@@ -67,7 +67,7 @@ reader = memory.uint8_view pointer
 # Go read. We know `Hello, World!` is 13 bytes long.
 #
 # Don't forget that we read bytes. We need to decode them!
-returned_string = reader.take(13).pack("U*")
+returned_string = reader.take(13).pack("C*").force_encoding('utf-8')
 
 assert { returned_string == 'Hello, World!' }
 


### PR DESCRIPTION
This PR updates the example in examples/exports_memory.rb to properly convert the bytes pulled from the `Wasmer::Memory` to UTF-8.

## Reproduce
If you modify string used in the example to be `"😀"` instead of `"Hello, World"`,  the `returned_string` will be `"ð\u009F\u0098\u0080"`.

## Explanation
`pack("U*")` was treating them as codepoints, which happens to work with ASCII, but not with characters that use more than 1 byte.

The 😀 utf-8 character is 4 bytes long, but 1 codepoint:

```ruby
"😀".bytes      # => [240, 159, 152, 128]
"😀".codepoints # => [128512]
```

`U*` is for codepoints, not bytes:
```ruby
"😀".bytes.pack("U*")      # => "ð\u009F\u0098\u0080"
"😀".codepoints.pack("U*") # => "😀"
```

`C*` is for bytes:
```ruby
"😀".bytes.pack("C*").force_encoding('utf-8') # => "😀"
```

Reference: https://ruby-doc.org/core-3.0.2/Array.html#method-i-pack