### PR TITLE
bundler min version from 2.1 to 1.17.3

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,8 @@
 # Compile and install the Ruby extension.
 build:
 	rake build_lib
-	rake bundle_install
+	bundle install
+	# rake bundle_install
 
 # Run all the tests.
 test-all: test-lib test-doc test-example

--- a/wasmer.gemspec
+++ b/wasmer.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = %w(lib)
 
-  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "minitest-reporters"  
+  spec.add_development_dependency "minitest-reporters"
 end


### PR DESCRIPTION
Reducing the minimum version of bundler from `2.1` to `1.17.3`. We have a service which requires bundler version lower than `2.1`. 

Reducing it for wider audience to use this. Build succeeds