### PR TITLE
Allow bundler 2.0

### DIFF
--- a/wasmer.gemspec
+++ b/wasmer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = %w(lib)
 
-  spec.add_development_dependency "bundler", "~> 1.17.3"
+  spec.add_development_dependency "bundler", ">= 1.17.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"


### PR DESCRIPTION
This change will allow bundler version 2 as well as 1 to be accepted and pass GitHub Actions test.
I think this is more appropriate given that [it was previously 2.1](https://github.com/wasmerio/wasmer-ruby/pull/67)
Rails also uses `>=` to [specify the bundler version](https://github.com/rails/rails/blob/a7902034089e8b6bff747c08d93eeac4b1377032/rails.gemspec#L45).

